### PR TITLE
Fixed post-install failure on rpm-ostree distros

### DIFF
--- a/rpm/brave-keyring.spec
+++ b/rpm/brave-keyring.spec
@@ -9,6 +9,7 @@ Source0:    ./brave-keyring-source.tar.gz
 BuildArch:  noarch
 
 Requires:   at
+Requires:   cronie
 
 %description
 The Brave keyring setup installs the keyring files necessary for validating
@@ -39,8 +40,7 @@ mkdir -p %{buildroot}/etc/yum.repos.d
 /usr/lib/sysctl.d/50-brave.conf
 
 %post
-service atd start
-echo "sh /etc/cron.daily/brave-key-updater" | at now + 2 minute > /dev/null 2>&1
+sh -c "/etc/cron.daily/brave-key-updater"
 
 %changelog
 


### PR DESCRIPTION
rpm-ostree based distros like CoreOS and Silverblue fail at post install scripts. This is because systemctl has been wrapped by the following script that ignores everything in %post except except for preset or --root commands as seen here: https://github.com/coreos/rpm-ostree/blob/main/src/libpriv/systemctl-wrapper.sh

We can just call brave-key-updater directly.

Error:

```
$ rpm-ostree install brave-browser
.
.
.
Running post scripts... done
error: Running %post for brave-keyring: bwrap(/bin/sh): Child process killed by signal 1; run `journalctl -t 'rpm-ostree(brave-keyring.post)'` for more information
```

```
$ journalctl -t 'rpm-ostree(brave-keyring.post)'
.
.
.
Feb 08 17:30:12 aqeel rpm-ostree(brave-keyring.post)[8001]: Redirecting to /bin/systemctl start atd.service
Feb 08 17:30:12 aqeel rpm-ostree(brave-keyring.post)[8001]: rpm-ostree-systemctl: Ignored non-preset command: start atd.service
```